### PR TITLE
Upgrading to the latest version of native-or-another

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "chalk": "^2.0.1",
     "keypress": "~0.2.1",
-    "native-or-another": "~2.0.0"
+    "native-or-another": "~5.0.1"
   },
   "devDependencies": {
     "bluebird": "^2.4.1",


### PR DESCRIPTION
Fixes deprecation warning, "npm WARN deprecated native-or-bluebird@1.2.0: 'native-or-bluebird' is deprecated. Please use 'any-promise' instead."